### PR TITLE
Add Codex composer icon

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -13,6 +13,7 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Spec Driven",
+    "composerIcon": "./assets/spec-driven-icon.svg",
     "shortDescription": "Turn feature ideas into requirements, design docs, tasks, and execution loops.",
     "longDescription": "A structured spec-driven development workflow for Codex. It guides features through brainstorming, EARS requirements, technical design, task breakdown, validation, execution, and post-completion review.",
     "developerName": "habib0x",

--- a/assets/spec-driven-icon.svg
+++ b/assets/spec-driven-icon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Spec Driven</title>
+  <desc id="desc">A teal document icon with structured checklist lines and a connected workflow mark.</desc>
+  <rect width="512" height="512" rx="96" fill="#0f766e"/>
+  <path d="M158 92h148l72 72v256H158z" fill="#f8fafc"/>
+  <path d="M306 92v72h72z" fill="#ccfbf1"/>
+  <path d="M182 420h196v-28H182z" fill="#99f6e4"/>
+  <circle cx="218" cy="202" r="18" fill="#0f766e"/>
+  <circle cx="218" cy="276" r="18" fill="#0f766e"/>
+  <circle cx="218" cy="350" r="18" fill="#0f766e"/>
+  <path d="M258 192h76v20h-76zm0 74h92v20h-92zm0 74h62v20h-62z" fill="#134e4a"/>
+  <path d="M218 220v38m0 36v38" fill="none" stroke="#14b8a6" stroke-width="14" stroke-linecap="round"/>
+  <path d="M174 154h76" fill="none" stroke="#14b8a6" stroke-width="18" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- add a 512x512 SVG icon for the plugin
- wire interface.composerIcon in .codex-plugin/plugin.json

## Validation
- python3 -m json.tool .codex-plugin/plugin.json
- xmllint --noout assets/spec-driven-icon.svg